### PR TITLE
Add some missing functions in string.h: strpbrk, strspn, strtok_r and strtok

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -95,13 +95,20 @@ char *strcat(char *dst, const char *src);
     the end of the dst string. */
 char *strncat(char *dst, const char *src, size_t length);
 
+char *strpbrk(const char *s1, const char *s2);
+
+/** Get length of the maximum initial segment
+    Return Length in number of characters */
+size_t strspn(const char *s1, const char *s2);
+
+/** Find string separator token
+    Return pointer to string or null */
+char* strtok_r(char *s, const char *delimiters, char **save_ptr);
+char *strtok(char *source, const char *delimiters);
+
 /* TODO */
 char *strerror(int errnum);
 
-char *strpbrk(const char *s1, const char *s2);
-
-size_t strspn(const char *s1, const char *s2);
 char *strstr(const char *s1, const char *s2);
-char *strtok(char *source, const char *delimiters);
 
 #endif

--- a/string/Makefile
+++ b/string/Makefile
@@ -5,6 +5,7 @@ INCL=-I../include
 SRCC=strchr.c strrchr.c memchr.c memcmp.c 
 SRCC+=strlen.c strcpy.c strncpy.c strcmp.c strncmp.c strcoll.c
 SRCC+=strcat.c strncat.c strxfrm.c
+SRCC+=strpbrk.c strspn.c strtok_r.c strtok.c
 SRCS=bzero.s bcopy.s
 OBJS=$(SRCC:.c=.o) $(SRCS:.s=.o)
 

--- a/string/strpbrk.c
+++ b/string/strpbrk.c
@@ -1,0 +1,36 @@
+/* Jaguar C library */
+/* Copyright (C) 2006 Seb/The Removers */
+/* http://removers.atari.org/ */
+
+/* This library is free software; you can redistribute it and/or */
+/* modify it under the terms of the GNU Lesser General Public */
+/* License as published by the Free Software Foundation; either */
+/* version 2.1 of the License, or (at your option) any later version. */
+
+/* This library is distributed in the hope that it will be useful, */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
+/* Lesser General Public License for more details. */
+
+/* You should have received a copy of the GNU Lesser General Public */
+/* License along with this library; if not, write to the Free Software */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#include "string.h"
+
+char* strpbrk(const char *str, const char *set)
+{
+    while (*str != '\0')
+    {
+        if (strchr(set, *str) == NULL)
+        {
+            ++str;
+        }
+        else
+        {
+            return (char *) str;
+        }
+    }
+
+    return NULL;
+}

--- a/string/strspn.c
+++ b/string/strspn.c
@@ -1,0 +1,48 @@
+/* Jaguar C library */
+/* Copyright (C) 2006 Seb/The Removers */
+/* http://removers.atari.org/ */
+
+/* This library is free software; you can redistribute it and/or */
+/* modify it under the terms of the GNU Lesser General Public */
+/* License as published by the Free Software Foundation; either */
+/* version 2.1 of the License, or (at your option) any later version. */
+
+/* This library is distributed in the hope that it will be useful, */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
+/* Lesser General Public License for more details. */
+
+/* You should have received a copy of the GNU Lesser General Public */
+/* License along with this library; if not, write to the Free Software */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#include "string.h"
+
+size_t strspn(const char *s, const char *accept)
+{
+    const char *p;
+    const char *a;
+    size_t count = 0;
+
+    for (p = s; *p != '\0'; ++p)
+    {
+        for (a = accept; *a != '\0'; ++a)
+        {
+            if (*p == *a)
+            {
+                break;
+            }
+        }
+
+        if (*a == '\0')
+        {
+            return count;
+        }
+        else
+        {
+            ++count;
+        }
+    }
+
+    return count;
+}

--- a/string/strtok.c
+++ b/string/strtok.c
@@ -1,0 +1,26 @@
+/* Jaguar C library */
+/* Copyright (C) 2006 Seb/The Removers */
+/* http://removers.atari.org/ */
+
+/* This library is free software; you can redistribute it and/or */
+/* modify it under the terms of the GNU Lesser General Public */
+/* License as published by the Free Software Foundation; either */
+/* version 2.1 of the License, or (at your option) any later version. */
+
+/* This library is distributed in the hope that it will be useful, */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
+/* Lesser General Public License for more details. */
+
+/* You should have received a copy of the GNU Lesser General Public */
+/* License along with this library; if not, write to the Free Software */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#include "string.h"
+
+static char *save = 0;
+
+char* strtok(char *s, const char *delim)
+{
+    return strtok_r(s, delim, &save);
+}

--- a/string/strtok_r.c
+++ b/string/strtok_r.c
@@ -1,0 +1,50 @@
+/* Jaguar C library */
+/* Copyright (C) 2006 Seb/The Removers */
+/* http://removers.atari.org/ */
+
+/* This library is free software; you can redistribute it and/or */
+/* modify it under the terms of the GNU Lesser General Public */
+/* License as published by the Free Software Foundation; either */
+/* version 2.1 of the License, or (at your option) any later version. */
+
+/* This library is distributed in the hope that it will be useful, */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
+/* Lesser General Public License for more details. */
+
+/* You should have received a copy of the GNU Lesser General Public */
+/* License along with this library; if not, write to the Free Software */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#include "string.h"
+
+char* strtok_r(char *s, const char *delim, char **save_ptr)
+{
+    char *token;
+
+    token = NULL;             /* Initialize to no token. */
+
+    if (s == NULL)            /* If not first time called... */
+    {
+        s = *save_ptr;            /* restart from where we left off. */
+    }
+        
+    if (s != 0)               /* If not finished... */
+    {
+        *save_ptr = 0;
+
+        s += strspn(s, delim);    /* Skip past any leading delimiters. */
+        if (*s != '\0')           /* We have a token. */
+        {
+            token = s;
+            *save_ptr = strpbrk(token, delim); /* Find token's end. */
+            if (*save_ptr != 0)
+            {
+                /* Terminate the token and make SAVE_PTR point past it.  */
+                *(*save_ptr)++ = '\0';
+            }
+        }
+    }
+
+    return token;
+}


### PR DESCRIPTION
Add 4 functions that were missing from the standard C library string.h
These had to be implemented as part of the Kings of Edom game for Atari Jaguar.